### PR TITLE
fix: twitter links

### DIFF
--- a/posts/before-an-example-proposal.mdx
+++ b/posts/before-an-example-proposal.mdx
@@ -19,17 +19,17 @@ Then, I include the following quotes, gathered after my most-recent talk:
 
 <Tweet
   text="@r00k you're one of the best presentors I've ever seen in tech."
-  link="https://twitter.com/#!/sayhar/status/165851089860702208"
+  link="https://twitter.com/sayhar/status/165851089860702208"
 />
 
 <Tweet
   text="@r00k and what a presentation it was. i wish you were my public speaking professor."
-  link="https://twitter.com/#!/tony_ciampa/status/165954726695944193"
+  link="https://twitter.com/tony_ciampa/status/165954726695944193"
 />
 
 <Tweet
   text="@r00k is killing - calisthenics, comedy, hecklers, and great super-fast coding w/ vim"
-  link="https://twitter.com/#!/pattytoland/status/165849474747469824"
+  link="https://twitter.com/pattytoland/status/165849474747469824"
 />
 
 Bio: Ben has spoken in several countries and in multiple languages, in venues varying from tiny conference rooms to giant lecture halls.


### PR DESCRIPTION
The links with the shebang are redirecting me to the main page. Not sure if that's a temporary issue or a permanent change.